### PR TITLE
ADX-281 Include resource ID in job logs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ var
 sdist
 develop-eggs
 .installed.cfg
+venv
 
 # Installer logs
 pip-log.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.8
 COPY requirements-dev.txt /tmp/requirements-dev.txt
 COPY requirements.txt /tmp/requirements.txt
 RUN pip3 install --upgrade pip &&\

--- a/datapusher/geojson2csv.py
+++ b/datapusher/geojson2csv.py
@@ -42,8 +42,10 @@ def convert(file, logger):
             writer.writerow(row)
 
         except KeyError as e:
+            logger.exception(e)
             raise util.JobError("GeoJSON feature must have 'properties' and 'geometry' fields.")
         except ValueError as e:
+            logger.exception(e)
             raise util.JobError("Each GeoJSON feature must have the same properties in order to convert to table. ")
 
     if not outfile.tell():

--- a/datapusher/jobs.py
+++ b/datapusher/jobs.py
@@ -324,7 +324,6 @@ def push_to_datastore(task_id, input, dry_run=False):
     logger = logging.getLogger(task_id)
     logger.addHandler(handler)
     logger.setLevel(logging.DEBUG)
-
     validate_input(input)
 
     data = input['metadata']
@@ -332,6 +331,11 @@ def push_to_datastore(task_id, input, dry_run=False):
     ckan_url = data['ckan_url']
     resource_id = data['resource_id']
     api_key = input.get('api_key')
+
+    formatter = logging.Formatter('%(levelname)s:{} %(message)s'.format(resource_id))
+    stream_handler = logging.StreamHandler()
+    stream_handler.setFormatter(formatter)
+    logger.addHandler(stream_handler)
 
     try:
         resource = get_resource(resource_id, ckan_url, api_key)

--- a/datapusher/jobs.py
+++ b/datapusher/jobs.py
@@ -323,7 +323,14 @@ def push_to_datastore(task_id, input, dry_run=False):
     handler = util.StoringHandler(task_id, input)
     logger = logging.getLogger(task_id)
     logger.addHandler(handler)
+    logging_id = input.get("metadata", {}).get("resource_id", "None")
+    formatter = logging.Formatter(f'[%(asctime)s] %(levelname)s - resource_id:{logging_id} - %(message)s')
+    stream_handler = logging.StreamHandler()
+    stream_handler.setFormatter(formatter)
+    logger.addHandler(stream_handler)
+    logger.propagate = False
     logger.setLevel(logging.DEBUG)
+
     validate_input(input)
 
     data = input['metadata']
@@ -332,10 +339,6 @@ def push_to_datastore(task_id, input, dry_run=False):
     resource_id = data['resource_id']
     api_key = input.get('api_key')
 
-    formatter = logging.Formatter('%(levelname)s:{} %(message)s'.format(resource_id))
-    stream_handler = logging.StreamHandler()
-    stream_handler.setFormatter(formatter)
-    logger.addHandler(stream_handler)
 
     try:
         resource = get_resource(resource_id, ckan_url, api_key)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 -r requirements.txt
 httpretty==0.9.4
 nose==1.3.7
-pandas==0.24.2
+pandas==1.1.2


### PR DESCRIPTION
I want to ensure that the resource ID for the datapusher job is included in all logs.  It is very hard to trace the error to a job/resource in the logs right now. 

I am struggling a bit though.  The logs appear twice in the logging stream, once with the correct format and once without. .  Maybe @tomeksabala could offer some thoughts? The setup uses a Handler defined in CKAN service provider that also stores logs to the database, but I want to be able to browse logs in Cloudwatch.

