### PR TITLE
ADX 606 Accept wrong content type

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ RUN chown -R www-data:www-data $DATAPUSHER_DIR
 
 ENV LC_ALL=C
 ENTRYPOINT ["./datapusher-entrypoint.sh"]
-CMD /usr/local/bin/uwsgi --ini-paste $DATAPUSHER_DIR/deployment/datapusher-uwsgi.ini --honour-stdin
+CMD /usr/local/bin/uwsgi --ini-paste $DATAPUSHER_DIR/deployment/datapusher-uwsgi.ini

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ RUN chown -R www-data:www-data $DATAPUSHER_DIR
 
 ENV LC_ALL=C
 ENTRYPOINT ["./datapusher-entrypoint.sh"]
-CMD /usr/local/bin/uwsgi --ini-paste $DATAPUSHER_DIR/deployment/datapusher-uwsgi.ini
+CMD /usr/local/bin/uwsgi --ini-paste $DATAPUSHER_DIR/deployment/datapusher-uwsgi.ini --honour-stdin

--- a/datapusher/jobs.py
+++ b/datapusher/jobs.py
@@ -429,7 +429,7 @@ def push_to_datastore(task_id, input, dry_run=False):
     try:
         table_set = messytables.any_tableset(tmp, mimetype=ct, extension=ct)
     except messytables.ReadError as e:
-        read_exception = e
+        logger.warning("First attempt to read table failed: {}".format(e))
 
     # try again with format inferred from url
     if not table_set or not table_set.tables:
@@ -438,11 +438,11 @@ def push_to_datastore(task_id, input, dry_run=False):
             extension = resource.get('format')
             format = mimetypes.guess_type(url)[0]
             table_set = messytables.any_tableset(tmp, mimetype=format, extension=extension)
-        except Exception:
-            raise util.JobError(read_exception)
+        except messytables.ReadError as e:
+            raise util.JobError(e)
 
-        if not table_set or not table_set.tables:
-            raise util.JobError("Unable to read any tabular data from the file.")
+    if not table_set or not table_set.tables:
+        raise util.JobError("Unable to read any tabular data from the file.")
 
     get_row_set = web.app.config.get('GET_ROW_SET',
                                      lambda table_set: table_set.tables.pop())

--- a/datapusher/jobs.py
+++ b/datapusher/jobs.py
@@ -426,14 +426,13 @@ def push_to_datastore(task_id, input, dry_run=False):
         logger.info('Done.')
         ct = 'application/csv'
 
-    read_exception = None
     try:
         table_set = messytables.any_tableset(tmp, mimetype=ct, extension=ct)
     except messytables.ReadError as e:
         read_exception = e
 
     # try again with format inferred from url
-    if not table_set.tables:
+    if not (hasattr(table_set, 'tables') and table_set.tables):
         tmp.seek(0)
         try:
             extension = resource.get('format')
@@ -442,7 +441,7 @@ def push_to_datastore(task_id, input, dry_run=False):
         except Exception:
             raise util.JobError(read_exception)
 
-        if not table_set.tables:
+        if not (hasattr(table_set, 'tables') and table_set.tables):
             raise util.JobError("Unable to read any tabular data from the file.")
 
     get_row_set = web.app.config.get('GET_ROW_SET',

--- a/datapusher/jobs.py
+++ b/datapusher/jobs.py
@@ -432,7 +432,7 @@ def push_to_datastore(task_id, input, dry_run=False):
         read_exception = e
 
     # try again with format inferred from url
-    if not (hasattr(table_set, 'tables') and table_set.tables):
+    if not table_set or not table_set.tables:
         tmp.seek(0)
         try:
             extension = resource.get('format')
@@ -441,7 +441,7 @@ def push_to_datastore(task_id, input, dry_run=False):
         except Exception:
             raise util.JobError(read_exception)
 
-        if not (hasattr(table_set, 'tables') and table_set.tables):
+        if not table_set or not table_set.tables:
             raise util.JobError("Unable to read any tabular data from the file.")
 
     get_row_set = web.app.config.get('GET_ROW_SET',

--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -256,6 +256,32 @@ class TestImport(unittest.TestCase):
              'temperature': 1})
 
     @httpretty.activate
+    def test_csv_with_html_content_type(self):
+        """Test successfully fetching and parsing a simple CSV file when the
+        content type specified is text/html not csv.
+        """
+        self.register_urls(content_type="text/html")
+        data = {
+            'api_key': self.api_key,
+            'job_type': 'push_to_datastore',
+            'metadata': {
+                'ckan_url': 'http://%s/' % self.host,
+                'resource_id': self.resource_id
+            }
+        }
+
+        headers, results = jobs.push_to_datastore('fake_id', data, True)
+        results = list(results)
+        assert_equal(headers, [{'type': 'timestamp', 'id': 'date'},
+                               {'type': 'numeric', 'id': 'temperature'},
+                               {'type': 'text', 'id': 'place'}])
+        assert_equal(len(results), 6)
+        assert_equal(
+            results[0],
+            {'date': datetime.datetime(2011, 1, 1, 0, 0), 'place': 'Galway',
+             'temperature': 1})
+
+    @httpretty.activate
     def test_simple_tsv(self):
         """Test successfully fetching and parsing a simple TSV file.
 
@@ -373,8 +399,7 @@ class TestImport(unittest.TestCase):
                                {'type': 'numeric', 'id': 'Internal Ref'},
                                {'type': 'text', 'id': 'Capital/ Revenue'},
                                {'type': 'text', 'id': 'Cost Centre'},
-                               {'type': 'text',
-                                'id': 'Cost Centre Description'},
+                               {'type': 'text', 'id': 'Cost Centre Description'},
                                {'type': 'numeric', 'id': 'Grand Total'}])
         assert_equal(len(results), 230)
         assert_equal(results[0],

--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -399,7 +399,8 @@ class TestImport(unittest.TestCase):
                                {'type': 'numeric', 'id': 'Internal Ref'},
                                {'type': 'text', 'id': 'Capital/ Revenue'},
                                {'type': 'text', 'id': 'Cost Centre'},
-                               {'type': 'text', 'id': 'Cost Centre Description'},
+                               {'type': 'text',
+                                'id': 'Cost Centre Description'},
                                {'type': 'numeric', 'id': 'Grand Total'}])
         assert_equal(len(results), 230)
         assert_equal(results[0],


### PR DESCRIPTION
If the initial attempt to parse a table using the specified content type fails, and no tables are found, the datapusher job fails with an uncaught exception:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/httpretty/core.py", line 1627, in wrapper
    return test(*args, **kw)
  File "/var/www/datapusher/tests/test_acceptance.py", line 273, in test_csv_with_html_content_type
    headers, results = jobs.push_to_datastore('fake_id', data, True)
  File "/var/www/datapusher/datapusher/jobs.py", line 443, in push_to_datastore
    row_set = get_row_set(table_set)
  File "/var/www/datapusher/datapusher/jobs.py", line 442, in <lambda>
    lambda table_set: table_set.tables.pop())
IndexError: pop from empty list
```

It is trying pop a table from an empty list of parsed tables. Datapusher should handle this properly. 

Datapusher is already catching a messytables read error and re trying the messy tables parsing with some subtly different config.  This config can be improved. 

This PR addresses both these issues, with the result being that a CSV files submitted with a content-type of text/html is still parsed as a CSV by messy tables. 