### PR TITLE
ADX-653 Give ckan time to update the resource metadata.

### DIFF
--- a/datapusher/jobs.py
+++ b/datapusher/jobs.py
@@ -341,6 +341,7 @@ def push_to_datastore(task_id, input, dry_run=False):
     api_key = input.get('api_key')
 
     try:
+        time.sleep(1)  # HACK: Give CKAN time to update the resource
         resource = get_resource(resource_id, ckan_url, api_key)
     except util.JobError as e:
         # try again in 5 seconds just incase CKAN is slow at adding resource
@@ -363,6 +364,7 @@ def push_to_datastore(task_id, input, dry_run=False):
     # fetch the resource data
     logger.info('Fetching from: {0}'.format(url))
     headers = {}
+
     if resource.get('url_type') == 'upload':
         # If this is an uploaded file to CKAN, authenticate the request,
         # otherwise we won't get file from private resources


### PR DESCRIPTION
Giftless seems to have lengthed the time to create/update resource.  

Datapusher requests the resource metadata, and with giftless in place, datapusher now seems to have been requesting it too soon as CKAN has been returning old resource metadata pointing to the old file rather than the newly uploaded file. 

This is a small hack to get datapusher working smoothly again with the new giftless setup.  We will revisit it later.

We're simply waiting a second before requesting the resource metadata, this means we get the correct metadata pointing to the newly uploaded file, and everything works again. 