### PR TITLE
Fix dependencies.

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -21,5 +21,5 @@ phases:
     commands:
       - echo Build completed on `date`
       - echo Pushing the Docker image...
-      - docker push 254010146609.dkr.ecr.eu-west-1.amazonaws.com/datapusher
+      - docker push --all-tags 254010146609.dkr.ecr.eu-west-1.amazonaws.com/datapusher
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ messytables==0.15.2
 certifi
 requests[security]==2.24.0
 ijson==3.1.1
+# newer versions of Werkzeug not compatilbe with ckanserviceprovider
+Werkzeug~=2.0.0


### PR DESCRIPTION
This is to resolve issue with incompatible Werkzeug version with ckanserviceprovider
https://stackoverflow.com/questions/71652965/importerror-cannot-import-name-safe-str-cmp-from-werkzeug-security