### PR TITLE
fix(deps): pin Flask/Werkzeug and add PasteDeploy so datapusher boots

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
 argparse
+Flask==2.1.3
+Werkzeug==2.1.2
+PasteDeploy
 ckanserviceprovider==1.2.0
 html5lib==1.0.1
 messytables==0.15.2


### PR DESCRIPTION
## Summary
Datapusher fails to boot on the current stack: `ckanserviceprovider==1.2.0` leaves Flask unpinned, so pip resolves **Flask 3.x + Flask-Login 0.6.0**, which are incompatible — Flask-Login imports `flask._request_ctx_stack`, removed in Flask 2.3 — so the uWSGI app fails to load (`ImportError`). Separately, the uWSGI `--ini-paste` entrypoint needs `PasteDeploy`, which wasn't installed.

## Change
Pin a compatible Flask stack and add the missing build dep in `requirements.txt`:
- `Flask==2.1.3` (still exposes `_request_ctx_stack`, so Flask-Login 0.6.0 works)
- `Werkzeug==2.1.2` (matching)
- `PasteDeploy` (for `uwsgi --ini-paste`)

## Verification
With these pins the datapusher container boots cleanly (`WSGI app 0 ... ready`, workers spawned, no import errors) and responds to CKAN — verified on the ADR deploy: resource→datastore pushes complete after this fix.
